### PR TITLE
Fix new clippy lints

### DIFF
--- a/crates/rlox/src/chunk.rs
+++ b/crates/rlox/src/chunk.rs
@@ -3,7 +3,7 @@ use std::io;
 use crate::value::{Value, ValuePosition, Values};
 
 /// Instruction to carry out a particular operation.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum OpCode {
     /// Load a constant for use.
     Constant(ValuePosition),

--- a/crates/rlox/src/value.rs
+++ b/crates/rlox/src/value.rs
@@ -14,7 +14,7 @@ pub enum Value {
 pub struct Values(Vec<Value>);
 
 /// Position of value in [`Values`].
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct ValuePosition(usize);
 
 impl Values {


### PR DESCRIPTION
Fix clippy lints added in Rust v1.63.
